### PR TITLE
Avoid an expected error

### DIFF
--- a/module/web/ServerThread.py
+++ b/module/web/ServerThread.py
@@ -66,7 +66,10 @@ class WebServer(threading.Thread):
 
 
         if self.server == "fastcgi":
-            self.start_fcgi()
+            try
+                self.start_fcgi()
+            except ValueError:    
+                pass
         elif self.server == "threaded":
             self.start_threaded()
         elif self.server == "lightweight":


### PR DESCRIPTION
Running the FastCGI _flup_ server launch a **_ValueError**_ as the webserver thread does not run as the main one and it can't catch keyboard shut-down commands (ex. CTRL+C).
The webserver is stopped properly (should be) by the PyLoad main thread, so the exception is expected.
